### PR TITLE
ci: manual PyPI release and dependency submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,47 @@
+name: Dependency submission
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  workflow_dispatch:
+
+# Required for the dependency submission API (see actions/component-detection-dependency-submission-action).
+permissions:
+  contents: write
+  id-token: write
+
+jobs:
+  dependency-submission:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      # Root requirements.txt pulls a very large optional stack and duplicates resolution from
+      # setup.py / pyproject.toml. Stash it so PipReport focuses on installable package manifests.
+      - name: Stash broad requirements for graph scan
+        run: |
+          mkdir -p .graph-scan-stash
+          if [ -f requirements.txt ]; then
+            mv requirements.txt .graph-scan-stash/requirements.txt
+          fi
+
+      - name: Submit dependencies to GitHub
+        id: submit
+        continue-on-error: true
+        uses: actions/component-detection-dependency-submission-action@374343effede691df3a5ffaf36b4e7acab919590
+        with:
+          detectorsFilter: PipReport
+          detectorsCategories: Python
+          directoryExclusionList: ".graph-scan-stash"
+
+      - name: Report submission failure
+        if: steps.submit.outcome == 'failure'
+        run: |
+          echo "::warning::Dependency snapshot upload failed (often a transient GitHub API error). Re-run this workflow; the job is green because submission uses continue-on-error."

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,12 +1,19 @@
-# Build wheels/sdist, create a GitHub Release with auto-generated notes, and publish to PyPI.
-# Trigger: push a semver tag, for example:
-#   git tag -a v1.0.5 -m "Release v1.0.5" && git push origin v1.0.5
+# Build wheels/sdist, create a GitHub Release, and publish to PyPI — **manual only**.
+#
+# 1. Push an annotated tag to the commit you want to ship, e.g.:
+#      git tag -a v1.0.6 -m "Release v1.0.6" && git push origin v1.0.6
+# 2. In GitHub: Actions → "Release and publish" → Run workflow → enter that tag as **ref** (e.g. v1.0.6).
+#
+# PyPI is not triggered by tag push; only this workflow_dispatch run publishes.
 name: Release and publish
 
 on:
-  push:
-    tags:
-      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Existing git tag to build and publish (e.g. v1.0.6). Push the tag before running."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -16,8 +23,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release ref
+        run: |
+          ref="${{ inputs.ref }}"
+          case "$ref" in
+            v*.*.*) ;;
+            *)
+              echo "::error::ref must be a semver-style tag on the remote (e.g. v1.0.6). Got: $ref"
+              exit 1
+              ;;
+          esac
+
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -40,6 +60,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -60,8 +82,13 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.ref }}
           files: dist/*
           generate_release_notes: true
+          fail_on_unmatched_files: true
+          make_latest: true
+          # Allow re-running this workflow for the same tag (e.g. after a transient PyPI failure).
+          allowUpdates: true
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dev = [
 ]
 docs = [
     "mkdocs>=1.6.0",
-    "mkdocs-material>=9.6.0",
+    "mkdocs-material>=9.7.0",
     "pymdown-extensions>=9.0",
     "pygments>=2.13.0",
 ]


### PR DESCRIPTION
## Summary
- **Publish / PyPI:** Release workflow now runs only on **workflow_dispatch** with a required **ref** (existing semver tag). Pushing a tag no longer publishes to PyPI. See workflow comments for the push-tag then run workflow steps.
- **Dependency graph:** Add **dependency-submission.yml** with \contents: write\ / \id-token: write\, resilient submission step, and stashed root \equirements.txt\ for a smaller PipReport snapshot.
- **Docs extra:** \mkdocs-material>=9.7.0\ in \pyproject.toml\ to align with pinned docs requirements.

## Verification
- \python -m build\ succeeded locally (Windows).
- **131 tests passed** in Docker (\python:3.12-bookworm\) with \pip install -r requirements.txt\ and \pip install -e .\, matching CI-style Linux environment.
- Host Python could not run pytest (NumPy 2 / SciPy ABI mismatch in the global Anaconda install); Docker run confirms the tree is sound.

Made with [Cursor](https://cursor.com)